### PR TITLE
volume mount subpath in deployment.yaml does not match configmap filename

### DIFF
--- a/helm-charts/safe-settings/templates/deployment-config.yaml
+++ b/helm-charts/safe-settings/templates/deployment-config.yaml
@@ -4,5 +4,5 @@ kind: ConfigMap
 metadata:
   name: deployment-config
 data:
-  deployment-config.yml: |
+  deployment-config.yaml: |
     {{- required "A valid appEnv.APP_ID is required!" .Values.deploymentConfig | toYaml | nindent 4 }}


### PR DESCRIPTION
The ConfigMap filename for deployment-config does not match the name in subpath of deployment.yaml file in the templates.  This causes the volume mount to create the ConfigMap volume as a directory instead of a file. 

