### PR TITLE
fix: convert appId to string

### DIFF
--- a/helm-charts/safe-settings/templates/app-env.yaml
+++ b/helm-charts/safe-settings/templates/app-env.yaml
@@ -5,7 +5,7 @@ metadata:
   name: app-env
 type: Opaque
 data:
-  APP_ID: {{ required "A valid appEnv.APP_ID is required!" .Values.appEnv.APP_ID | b64enc }}
+  APP_ID: {{ required "A valid appEnv.APP_ID is required!" .Values.appEnv.APP_ID | toString | b64enc }}
   PRIVATE_KEY: {{ required "A valid appEnv.PRIVATE_KEY is required!" .Values.appEnv.PRIVATE_KEY | b64enc }}
   WEBHOOK_SECRET: {{ required "A valid appEnv.WEBHOOK_SECRET is required!" .Values.appEnv.WEBHOOK_SECRET | b64enc }}
   DEPLOYMENT_CONFIG_FILE: {{ required "A valid appEnv.DEPLOYMENT_CONFIG_FILE is required!" .Values.appEnv.DEPLOYMENT_CONFIG_FILE | b64enc }}

--- a/helm-charts/safe-settings/values.yaml
+++ b/helm-charts/safe-settings/values.yaml
@@ -82,9 +82,9 @@ tolerations: []
 affinity: {}
 
 appEnv:
-  APP_ID: 
-  PRIVATE_KEY: 
-  WEBHOOK_SECRET: 
+  APP_ID: ""
+  PRIVATE_KEY: ""
+  WEBHOOK_SECRET: ""
 
 deploymentConfig: 
   restrictedRepos:


### PR DESCRIPTION
Fixes #2 

The blank value for `appEnv.APP_ID` in helm-charts/safe-settings/values.yaml causes a numeric AppId to be interpreted as an integer rather than a string when passed in a `--set` parameter to the helm cli:
```sh
$ helm upgrade --install safe-settings decyjphr/safe-settings -f values.yaml --set appEnv.APP_ID='123456'
Error: UPGRADE FAILED: template: safe-settings/templates/app-env.yaml:8:83: executing "safe-settings/templates/app-env.yaml" at <b64enc>: wrong type for value; expected string; got int64
```
This change converts the integer to a string. The only difference in the following command is to execute my fork of the chart:
```sh
helm upgrade --install safe-settings ./safe-settings -f values.yaml --set appEnv.APP_ID='123456'
Release "safe-settings" has been upgraded. Happy Helming!
NAME: safe-settings
LAST DEPLOYED: Fri Mar 24 16:16:44 2023
NAMESPACE: default
STATUS: deployed
REVISION: 3
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=safe-settings,app.kubernetes.io/instance=safe-settings" -o jsonpath="{.items[0].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod --namespace default $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl --namespace default port-forward $POD_NAME 8080:$CONTAINER_PORT
```

An alternative solution is to set the value in helm-charts/safe-settings/values.yaml to an empty string:
```diff
appEnv:
-  APP_ID:  
+  APP_ID:  ""
  PRIVATE_KEY:
  WEBHOOK_SECRET:
```
The same problem would occur with the WEBHOOK_SECRET if it happened to be purely numeric.

edit: I added a commit to also set the 3 empty values to empty strings