### PR TITLE
feat: add environment variables

### DIFF
--- a/helm-charts/safe-settings/templates/app-env.yaml
+++ b/helm-charts/safe-settings/templates/app-env.yaml
@@ -9,6 +9,8 @@ data:
   PRIVATE_KEY: {{ required "A valid appEnv.PRIVATE_KEY is required!" .Values.appEnv.PRIVATE_KEY | b64enc }}
   WEBHOOK_SECRET: {{ required "A valid appEnv.WEBHOOK_SECRET is required!" .Values.appEnv.WEBHOOK_SECRET | b64enc }}
   DEPLOYMENT_CONFIG_FILE: {{ required "A valid appEnv.DEPLOYMENT_CONFIG_FILE is required!" .Values.appEnv.DEPLOYMENT_CONFIG_FILE | b64enc }}
+  ADMIN_REPO: {{ .Values.appEnv.ADMIN_REPO | default "admin" | b64enc }}
+  SETTINGS_FILE_PATH: {{ .Values.appEnv.SETTINGS_FILE_PATH | default "settings.yml" | b64enc }}
   {{- if .Values.appEnv.CRON }}
   CRON: {{ .Values.appEnv.CRON | b64enc }}
   {{- end }}

--- a/helm-charts/safe-settings/templates/app-env.yaml
+++ b/helm-charts/safe-settings/templates/app-env.yaml
@@ -9,3 +9,7 @@ data:
   PRIVATE_KEY: {{ required "A valid appEnv.PRIVATE_KEY is required!" .Values.appEnv.PRIVATE_KEY | b64enc }}
   WEBHOOK_SECRET: {{ required "A valid appEnv.WEBHOOK_SECRET is required!" .Values.appEnv.WEBHOOK_SECRET | b64enc }}
   DEPLOYMENT_CONFIG_FILE: {{ required "A valid appEnv.DEPLOYMENT_CONFIG_FILE is required!" .Values.appEnv.DEPLOYMENT_CONFIG_FILE | b64enc }}
+  {{- if .Values.appEnv.CRON }}
+  CRON: {{ .Values.appEnv.CRON | b64enc }}
+  {{- end }}
+  LOG_LEVEL: {{ .Values.appEnv.LOG_LEVEL | default "info" | b64enc }}


### PR DESCRIPTION
Add values for optional environment variables supported by safe-settings:
- CRON is only added if it's value is non-empty
- LOG_LEVEL defaults to info if not specified
- ADMIN_REPO & SETTINGS_FILE_PATH follow defaults [as defined in safe-settings](https://github.com/github/safe-settings/blob/5dd324db866f814fd7db98d6dd8ebabf0c983885/lib/env.js)