### PR TITLE
feat: allow multiple deployments per namespace

### DIFF
--- a/helm-charts/safe-settings/templates/app-env.yaml
+++ b/helm-charts/safe-settings/templates/app-env.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: app-env
+  name: {{ include "safe-settings.fullname" . }}-app-env
 type: Opaque
 data:
   APP_ID: {{ required "A valid appEnv.APP_ID is required!" .Values.appEnv.APP_ID | b64enc }}

--- a/helm-charts/safe-settings/templates/deployment-config.yaml
+++ b/helm-charts/safe-settings/templates/deployment-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: deployment-config
+  name: {{ include "safe-settings.fullname" . }}-deployment-config
 data:
   deployment-config.yml: |
     {{- required "A valid appEnv.APP_ID is required!" .Values.deploymentConfig | toYaml | nindent 4 }}

--- a/helm-charts/safe-settings/templates/deployment.yaml
+++ b/helm-charts/safe-settings/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: deployment-config
+            name: {{ include "safe-settings.fullname" . }}-deployment-config
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -38,8 +38,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
-          - secretRef: 
-              name: app-env
+          - secretRef:
+              name: {{ include "safe-settings.fullname" . }}-app-env
           volumeMounts:
           - name: config-volume
             mountPath: {{ .Values.appEnv.DEPLOYMENT_CONFIG_FILE }}


### PR DESCRIPTION
Include the release name in the secret and config map names to allow multiple, independent release in a single namespace.