### PR TITLE
feat: add trusted certs for nodejs

### DIFF
--- a/helm-charts/safe-settings/templates/app-env.yaml
+++ b/helm-charts/safe-settings/templates/app-env.yaml
@@ -9,3 +9,4 @@ data:
   PRIVATE_KEY: {{ required "A valid appEnv.PRIVATE_KEY is required!" .Values.appEnv.PRIVATE_KEY | b64enc }}
   WEBHOOK_SECRET: {{ required "A valid appEnv.WEBHOOK_SECRET is required!" .Values.appEnv.WEBHOOK_SECRET | b64enc }}
   DEPLOYMENT_CONFIG_FILE: {{ required "A valid appEnv.DEPLOYMENT_CONFIG_FILE is required!" .Values.appEnv.DEPLOYMENT_CONFIG_FILE | b64enc }}
+  NODE_EXTRA_CA_CERTS: {{ .Values.appEnv.NODE_EXTRA_CA_CERTS | b64enc }}

--- a/helm-charts/safe-settings/templates/cacerts-cm.yaml
+++ b/helm-charts/safe-settings/templates/cacerts-cm.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.appEnv.NODE_EXTRA_CA_CERTS .Values.nodeExtraCaCerts }}
+{{- $fullName := include "safe-settings.fullname" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "safe-settings.fullname" . }}-trusted-cacerts
+data:
+  {{ .Values.appEnv.NODE_EXTRA_CA_CERTS }}:
+    {{- .Values.nodeExtraCaCerts | toYaml | nindent 4 }}
+{{- end }}

--- a/helm-charts/safe-settings/templates/deployment.yaml
+++ b/helm-charts/safe-settings/templates/deployment.yaml
@@ -31,6 +31,11 @@ spec:
         - name: config-volume
           configMap:
             name: deployment-config
+        {{- if and .Values.appEnv.NODE_EXTRA_CA_CERTS .Values.nodeExtraCaCerts }}
+        - name: cacert-volume
+          configMap:
+            name: {{ include "safe-settings.fullname" . }}-trusted-cacerts
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -38,12 +43,17 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
-          - secretRef: 
+          - secretRef:
               name: app-env
           volumeMounts:
           - name: config-volume
             mountPath: {{ .Values.appEnv.DEPLOYMENT_CONFIG_FILE }}
             subPath: deployment-config.yaml
+          {{- if and .Values.appEnv.NODE_EXTRA_CA_CERTS .Values.nodeExtraCaCerts }}
+          - name: cacert-volume
+            mountPath: "/opt/safe-settings/{{ .Values.appEnv.NODE_EXTRA_CA_CERTS }}"
+            subPath: {{ .Values.appEnv.NODE_EXTRA_CA_CERTS }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/helm-charts/safe-settings/values.yaml
+++ b/helm-charts/safe-settings/values.yaml
@@ -85,6 +85,7 @@ appEnv:
   APP_ID: 
   PRIVATE_KEY: 
   WEBHOOK_SECRET: 
+  NODE_EXTRA_CA_CERTS: ""
 
 deploymentConfig: 
   restrictedRepos:
@@ -120,3 +121,5 @@ deploymentConfig:
         Some error
       script: |
         return true
+
+nodeExtraCaCerts: ""


### PR DESCRIPTION
Allow passing trusted root CA certs to the node.js process using the env var `NODE_EXTRA_CA_CERTS`

In most corporate environments, outbound connections go through a proxy which does TLS inspection. This means that when safe-settings makes a call to github.com, it receives an untrusted response as the github.com cert will appear to be signed by an internal corporate CA which is unknown to node.js. Passing the corporate signing cert to the node.js process via the `NODE_EXTRA_CA_CERTS` environment variable allows the node.js process to confirm the validity of the cert that it sees presented by github.com.